### PR TITLE
Feat/validate tickers

### DIFF
--- a/src/vibe_trader_agent/nodes.py
+++ b/src/vibe_trader_agent/nodes.py
@@ -10,6 +10,7 @@ from langchain_openai import ChatOpenAI
 from langgraph.types import interrupt
 
 from vibe_trader_agent.configuration import Configuration
+from vibe_trader_agent.finance_tools import validate_ticker_exists
 from vibe_trader_agent.misc import get_current_date
 from vibe_trader_agent.optimization.params_validation import validate_optimizer_params
 from vibe_trader_agent.optimization.portfolio_optimizer import PortfolioOptimizer
@@ -28,7 +29,6 @@ from vibe_trader_agent.tools import (
     profile_builder_tools,
     views_analyst_tools,
 )
-from vibe_trader_agent.finance_tools import validate_ticker_exists
 from vibe_trader_agent.utils import concatenate_mandate_data, load_chat_model
 
 
@@ -198,15 +198,9 @@ async def asset_finder(state: State) -> Dict[str, Any]:
         if tool_call["name"] == "extract_tickers_data":
             # Tickers identified - update state and route to views analyst
             # Note: don't add tool-call message
-            tickers = tool_call["args"]
-
-            print(f"BEFORE: {tickers}")
-
-            # Validate tickers
+            tickers = tool_call["args"]            
             tickers["tickers"] = [t for t in tickers["tickers"] if validate_ticker_exists(t)]
-
-            print(f"AFTER: {tickers}")
-
+            
             result.update(tickers)
             result["next"] = "views_analyst"
             return result

--- a/src/vibe_trader_agent/nodes.py
+++ b/src/vibe_trader_agent/nodes.py
@@ -28,6 +28,7 @@ from vibe_trader_agent.tools import (
     profile_builder_tools,
     views_analyst_tools,
 )
+from vibe_trader_agent.finance_tools import validate_ticker_exists
 from vibe_trader_agent.utils import concatenate_mandate_data, load_chat_model
 
 
@@ -198,6 +199,14 @@ async def asset_finder(state: State) -> Dict[str, Any]:
             # Tickers identified - update state and route to views analyst
             # Note: don't add tool-call message
             tickers = tool_call["args"]
+
+            print(f"BEFORE: {tickers}")
+
+            # Validate tickers
+            tickers["tickers"] = [t for t in tickers["tickers"] if validate_ticker_exists(t)]
+
+            print(f"AFTER: {tickers}")
+
             result.update(tickers)
             result["next"] = "views_analyst"
             return result


### PR DESCRIPTION
Update: Filter out invalid tickers in asset_finder node

`APPL` typo of AAPL ticker (Appl) is filtered out as shown below in the logs:

Logs:
```
62f-66ca-b49f-156e3821cc94 run_queue_ms=649 run_started_at=2025-05-27T21:21:35.811085+00:00 thread_id=1fd6e56f-a11a-424c-bb15-d18d2dd3505e thread_name=asyncio_8
2025-05-27T21:21:36.910938Z [info     ] HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK" [httpx] api_variant=local_dev assistant_id=fe096781-5601-53d2-b2f6-0d3403f7e9ca graph_id=agent request_id=eb5df437-37cb-47b3-9d48-980500c0dfae run_attempt=1 run_id=1f03b409-162f-66ca-b49f-156e3821cc94 thread_id=1fd6e56f-a11a-424c-bb15-d18d2dd3505e thread_name=MainThread
BEFORE: {'tickers': ['APPL', 'MSFT', 'MNTN', 'GOOGL', 'TSM', 'NVDA', 'IONQ', 'AIQ', 'VGT', 'IEMG', 'VWO', 'ESGE', 'SCHE']}
2025-05-27T21:21:38.481148Z [error    ] $APPL: possibly delisted; no price data found  (period=5d) [yfinance] api_variant=local_dev assistant_id=fe096781-5601-53d2-b2f6-0d3403f7e9ca graph_id=agent request_id=eb5df437-37cb-47b3-9d48-980500c0dfae run_attempt=1 run_id=1f03b409-162f-66ca-b49f-156e3821cc94 thread_id=1fd6e56f-a11a-424c-bb15-d18d2dd3505e thread_name=MainThread
AFTER: {'tickers': ['MSFT', 'MNTN', 'GOOGL', 'TSM', 'NVDA', 'IONQ', 'AIQ', 'VGT', 'IEMG', 'VWO', 'ESGE', 'SCHE']}
2025-05-27T21:22:02.709161Z [info     ] HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK" [httpx] api_variant=local_dev assistant_id=fe096781-5601-53d2-b2f6-0d3403f7e9ca graph_id=agent request_id=eb5df437-37cb-47b3-9d48-980500c0dfae run_attempt=1 run_id=1f03b409-162f-66ca-b49f-156e3821cc94 thread_id=1fd6e56f-a11a-424c-bb15-d18d2dd3505e thread_name=MainThread
```